### PR TITLE
set output SHAREABLE_URL

### DIFF
--- a/src/nextcloud/NextcloudArtifact.ts
+++ b/src/nextcloud/NextcloudArtifact.ts
@@ -83,6 +83,7 @@ export class NextcloudArtifact {
 
     try {
       const shareableUrl = await client.uploadFiles(files.filesToUpload)
+      core.setOutput('SHAREABLE_URL', shareableUrl)
       core.info(`Nextcloud shareable URL: ${shareableUrl}`)
       const resp = await this.octokit.rest.checks.update({
         check_run_id: createResp.data.id,


### PR DESCRIPTION
hello, 

I wanted to use the URL after the upload in another step, so I exported the shareableUrl with core.setOutput.
https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions

thx :)